### PR TITLE
Slackからエクスポートしてローカルに保存するところまで

### DIFF
--- a/SlackExport/App.config
+++ b/SlackExport/App.config
@@ -19,5 +19,6 @@
 		<add key="token" value="SlackAPIのトークンをセットする" />
 		<add key="mySqlConnection" value="server=127.0.0.1;port=3306;uid=user;pwd=password;database=DiarySample" />
 		<add key="importFilePath" value="インポートファイルを格納しているフォルダのパスをセットする" />
+		<add key="daysAgo" value="90" />
 	</appSettings>
 </configuration>

--- a/SlackExport/Common/SlackApiAccess.cs
+++ b/SlackExport/Common/SlackApiAccess.cs
@@ -6,6 +6,8 @@ using Newtonsoft.Json.Linq;
 using NLog;
 using SlackExport.Dto;
 using System.IO.Compression;
+using System.Threading.Channels;
+using Amazon;
 
 
 namespace SlackExport.Common
@@ -16,7 +18,8 @@ namespace SlackExport.Common
 
         private static readonly string LIST_URL = "https://slack.com/api/conversations.list";
         private static readonly string HISTORY_URL = "https://slack.com/api/conversations.history";
-        private static readonly string USER_URL = "https://slack.com/api/users.info";
+        private static readonly string USER_INFO_URL = "https://slack.com/api/users.info";
+        private static readonly string USER_INFO_LIST = "https://slack.com/api/users.list";
 
         // TODO:App.configに移す想定
         private static readonly string ROOT_PATH = "./work";
@@ -26,18 +29,9 @@ namespace SlackExport.Common
 
         // タイムゾーンは、SlackからはUTCで取れるので、これを指定しておく
         private static DateTime unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-        public void Export(string token)
-        {
-            // チャンネル一覧を取得する
-            // https://slack.com/api/conversations.list
-            var channelDtoList = GetThreadId(token);
 
-            // チャンネルごとの投稿内容を取得する
-            // https://slack.com/api/conversations.history
-            GetMessage(channelDtoList, token);
-        }
 
-        private List<ChannelDto> GetThreadId(string token)
+        public List<ChannelDto> GetThreadId(string token)
         {
             var channelDtoList = new List<ChannelDto>();
             var httpAccess = new HttpAccess();
@@ -61,80 +55,65 @@ namespace SlackExport.Common
             return channelDtoList;
         }
 
+        public Dictionary<string, string> GetUserInfo(String token)
+        {
+            var httpAccess = new HttpAccess();
+            var response = httpAccess.get(USER_INFO_LIST, token);
+            var userJson = JObject.Parse(response);
 
-        private void GetMessage(List<ChannelDto> list, string token)
+            var ok = userJson["ok"];
+            if (!Convert.ToBoolean(ok.ToString()))
+            {
+                return new Dictionary<string, string>();
+            }
+
+            var userInfoDec = new Dictionary<string, string>();
+            var members = userJson["members"];
+            foreach (var member in members)
+            {
+                var id = member["id"];
+                var name = member["name"];
+
+                var profile = member["profile"];
+                var displayName = profile["display_name"];
+                userInfoDec.Add(id.ToString(), displayName.ToString());
+            }
+            return userInfoDec;
+        }
+
+
+        public string GetMessage(ChannelDto channelDto, DateTime startDate, DateTime endDate, string token)
         {
             CultureInfo.CurrentCulture = CultureInfo.CreateSpecificCulture("en-US");
-            var startDate = DateTime.MaxValue;
-            var endDate = DateTime.MinValue;
+
+            // UNIX時間に変換する
+            var startUnixTime = (startDate.ToUniversalTime() - unixEpoch).TotalSeconds;
+            var endUnixTime = (endDate.ToUniversalTime() - unixEpoch).TotalSeconds;
 
             var httpAccess = new HttpAccess();
+            var historyUrl = HISTORY_URL + "?channel=" + channelDto.channnelId + "&limit=100" + "&latest=" + endUnixTime + "&oldest=" + startUnixTime;
+            var response = httpAccess.get(historyUrl, token);
+            var historyJson = JObject.Parse(response);
 
-            foreach (var channel in list)
+            if (historyJson.Count <= 0)
             {
-
-                // 「tmp」フォルダを作成して、その中にチャンネルごとのフォルダを作る
-                Directory.CreateDirectory(ROOT_PATH + Path.DirectorySeparatorChar + "tmp" + Path.DirectorySeparatorChar + channel.channnelName);
-
-                // 〇日前まで取得対象にする
-                int daysAgo = int.Parse(ConfigurationManager.AppSettings["daysAgo"]);
-                var today = DateTime.Now;
-
-                // 本日からdaysAgoの日数分、1日分ずつ遡って取得していく
-                for (int i = 0; i <= daysAgo; i++)
-                {
-                    var targetDay = today.AddDays(i * -1);
-
-                    // 指定日の0時から23時59分59秒までを取得対象にする
-                    var startDate2 = DateTime.Parse(targetDay.ToString("yyyy/MM/dd") + " 00:00:00");
-                    var endDate2 = DateTime.Parse(targetDay.ToString("yyyy/MM/dd") + " 23:59:59");
-                    // UNIX時間に変換する
-                    var startUnixTime = (startDate2.ToUniversalTime() - unixEpoch).TotalSeconds;
-                    var endUnixTime = (endDate2.ToUniversalTime() - unixEpoch).TotalSeconds;
-
-                    var historyUrl = HISTORY_URL + "?channel=" + channel.channnelId + "&limit=100" + "&latest=" + endUnixTime + "&oldest=" + startUnixTime;
-                    var historyResponse = httpAccess.get(historyUrl, token);
-                    var historyJson = JObject.Parse(historyResponse);
-
-                    if (historyJson.Count <= 0)
-                    {
-                        logger.Info("レスポンスなし");
-                        break;
-                    }
-
-                    // messagesがあったらファイルに書き出す
-                    var message = historyJson["messages"];
-                    if ((message != null) &&
-                        (message.ToString() != null) &&
-                        (message.ToString() != "[]"))
-                    {
-                        File.AppendAllText(ROOT_PATH + Path.DirectorySeparatorChar + "tmp" + Path.DirectorySeparatorChar + channel.channnelName + Path.DirectorySeparatorChar + targetDay.ToString("yyyy-MM-dd") + ".json", message.ToString());
-
-                        // フォルダ名に取得した投稿の開始日と終了日を入れるため、
-                        // 取得対象範囲日の中から、
-                        // 実際に投稿を取得できた日時の開始日と終了日を覚えておく
-                        if (startDate.CompareTo(targetDay) > 0)
-                        {
-                            startDate = targetDay;
-                        }
-                        if (endDate.CompareTo(targetDay) < 0)
-                        {
-                            endDate = targetDay;
-                        }
-                    }
-                }
+                logger.Info("レスポンスなし。チャンネルID：" + channelDto.channnelId + " 取得範囲：" + startDate + " - " + endDate);
+                return string.Empty;
             }
-            var startDateStr = startDate.ToString("MMM dd yyyy");
-            var endDateStr = endDate.ToString("MMM dd yyyy");
 
-            // 「tmp」フォルダを「第一システム部（仮） Slack export MMM dd yyyy - MMM dd yyyy」の形式のフォルダにリネームする
-            string oldDir = ROOT_PATH + Path.DirectorySeparatorChar + "tmp";
-            string newDir = ROOT_PATH + Path.DirectorySeparatorChar + EXPORT_NAME + " " + startDateStr + " - " + endDateStr;
-            Directory.Move(oldDir, newDir);
-            // Zip圧縮する
-            ZipFile.CreateFromDirectory(newDir, newDir + ".zip");
-            // フォルダは消してZipファイルだけ残す
-            Directory.Delete(newDir, true);
+            var ok = historyJson["ok"];
+            if (!Convert.ToBoolean(ok.ToString()))
+            {
+                return string.Empty;
+            }
+
+            // messagesがあったらファイルに書き出す
+            var message = historyJson["messages"];
+            if (message.ToString() == "[]")
+            {
+                return string.Empty;
+            }
+            return message.ToString();
         }
     }
 }

--- a/SlackExport/Controller.cs
+++ b/SlackExport/Controller.cs
@@ -6,6 +6,8 @@ namespace SlackExport
     {
         private const string FileImport = "1";
 
+        private const string FileExport = "2";
+
         public void Execute(string param)
         {
             // コマンドライン引数で呼び出す機能を分岐する予定
@@ -13,8 +15,13 @@ namespace SlackExport
             {
                 // ファイルをDBにインポートする
                 case FileImport:
-                    var service = new FileImportService();
-                    service.Execute();
+                    var fileImportService = new FileImportService();
+                    fileImportService.Execute();
+                    break;
+                // ファイルをS3にエクスポートする
+                case FileExport:
+                    var fileExportService = new FileExportService();
+                    fileExportService.Execute();
                     break;
                 default:
                     break;

--- a/SlackExport/Program.cs
+++ b/SlackExport/Program.cs
@@ -7,14 +7,16 @@ namespace SlackExport
         public static Logger logger = LogManager.GetCurrentClassLogger();
 
         // コマンライン引数
-        // 1：S3バックアップ済のファイルの内容を、Diary Sampleのdiaryテーブルにインポートする
-        // 2：Slack APIを使用しSlackの投稿内容を取得して、S3に保存する（予定）
+        // 1：S3バックアップ済のファイルの内容を、Diary Sampleのdiaryテーブルにインポートする。
+        //    →現状はS3からダウンロードはせずに、ローカルからインポートしている。S3からダウンロードするようにしたい。（予定）
+        // 2：Slack APIを使用しSlackの投稿内容を取得して、S3に保存する。
+        //    →現状はローカルに保存している。S3にアップロードするようにしたい。（予定）
         // 3：Slack APIを使用しSlackの投稿内容を取得して、Diary Sampleのdiaryテーブルにインポートする（予定）
         public static void Main(string[] args)
         {
             logger.Info("処理開始");
 
-            if (args.Length != 1)
+            if (args.Length == 0)
             {
                 logger.Info("引数エラー");
             }

--- a/SlackExport/Service/FileExportService.cs
+++ b/SlackExport/Service/FileExportService.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Globalization;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using SlackExport.Common;
 
@@ -10,6 +13,14 @@ namespace SlackExport.Service
 {
     public class FileExportService
     {
+        // TODO:App.configに移す想定
+        private static readonly string ROOT_PATH = "./work";
+
+        private static readonly string EXPORT_NAME = "第一システム部（仮） Slack export";
+
+        // タイムゾーンは、SlackからはUTCで取れるので、これを指定しておく
+        private static DateTime unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+
         public FileExportService() { }
 
 
@@ -17,7 +28,80 @@ namespace SlackExport.Service
 
             string token = ConfigurationManager.AppSettings["token"];
             var slackApiAccess = new SlackApiAccess();
-            slackApiAccess.Export(token);
+            var channelDtoList = slackApiAccess.GetThreadId(token);
+
+
+            var userInfoDec = slackApiAccess.GetUserInfo(token);
+
+            CultureInfo.CurrentCulture = CultureInfo.CreateSpecificCulture("en-US");
+            var startDate = DateTime.MaxValue;
+            var endDate = DateTime.MinValue;
+            foreach (var channel in channelDtoList)
+            {
+                // 「tmp」フォルダを作成して、その中にチャンネルごとのフォルダを作る
+                Directory.CreateDirectory(ROOT_PATH + Path.DirectorySeparatorChar + "tmp" + Path.DirectorySeparatorChar + channel.channnelName);
+
+                // 〇日前まで取得対象にする
+                int daysAgo = int.Parse(ConfigurationManager.AppSettings["daysAgo"]);
+                var today = DateTime.Now;
+
+
+                // 本日からdaysAgoの日数分、1日分ずつ遡って取得していく
+                for (int i = 0; i <= daysAgo; i++)
+                {
+                    var targetDay = today.AddDays(i * -1);
+
+                    // 指定日の0時から23時59分59秒までを取得対象にする
+                    var startDate2 = DateTime.Parse(targetDay.ToString("yyyy/MM/dd") + " 00:00:00");
+                    var endDate2 = DateTime.Parse(targetDay.ToString("yyyy/MM/dd") + " 23:59:59");
+
+                    var message = slackApiAccess.GetMessage(channel, startDate2, endDate2, token);
+                    if (message != string.Empty)
+                    {
+ 
+                        File.AppendAllText(ROOT_PATH + Path.DirectorySeparatorChar + "tmp" + Path.DirectorySeparatorChar + channel.channnelName + Path.DirectorySeparatorChar + targetDay.ToString("yyyy-MM-dd") + ".json", message.ToString());
+
+                        // フォルダ名に取得した投稿の開始日と終了日を入れるため、
+                        // 取得対象範囲日の中から、
+                        // 実際に投稿を取得できた日時の開始日と終了日を覚えておく
+                        if (startDate.CompareTo(targetDay) > 0)
+                        {
+                            startDate = targetDay;
+                        }
+                        if (endDate.CompareTo(targetDay) < 0)
+                        {
+                            endDate = targetDay;
+                        }
+                    }
+                }
+            }
+
+            var startDateStr = startDate.ToString("MMM dd yyyy");
+            var endDateStr = endDate.ToString("MMM dd yyyy");
+
+            // 「tmp」フォルダを「第一システム部（仮） Slack export MMM dd yyyy - MMM dd yyyy」の形式のフォルダにリネームする
+            string oldDir = ROOT_PATH + Path.DirectorySeparatorChar + "tmp";
+            string newDir = ROOT_PATH + Path.DirectorySeparatorChar + EXPORT_NAME + " " + startDateStr + " - " + endDateStr;
+            string zipDir = newDir + ".zip";
+
+            Directory.Move(oldDir, newDir);
+            // Zipファイルが既に存在していたら消してしまう
+            if (File.Exists(zipDir))
+            {
+                File.Delete(zipDir);
+            }
+            // Zip圧縮する
+            ZipFile.CreateFromDirectory(newDir, zipDir);
+            // フォルダは消してZipファイルだけ残す
+            Directory.Delete(newDir, true);
+
+            // S3アクセス用の残骸です。いったん無視してください。
+            /*
+            AmazonS3Service amazonS3Service = new AmazonS3Service();
+
+            string bucketName = "1-system-group-slack-history";
+            amazonS3Service.UploadFile(bucketName, filePath);
+            */
         }
     }
 }

--- a/SlackExport/Service/FileExportService.cs
+++ b/SlackExport/Service/FileExportService.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SlackExport.Common;
+
+namespace SlackExport.Service
+{
+    public class FileExportService
+    {
+        public FileExportService() { }
+
+
+        public void Execute() {
+
+            string token = ConfigurationManager.AppSettings["token"];
+            var slackApiAccess = new SlackApiAccess();
+            slackApiAccess.Export(token);
+        }
+    }
+}


### PR DESCRIPTION
Slackからのエクスポート機能として、SlackAPIで投稿をエクスポートしてきて、
いったんローカルに保存するところまで作成しました。
App.configに、SlackAPIのトークンをセットする必要があります。

S3へのアップロードは未実装です。
これも別途実装して、インポートの方もS3からダウンロードしてインポートする。
という流れにしていきたいところです。