### PR TITLE
S3エクスポートの実装

### DIFF
--- a/SlackExport/App.config
+++ b/SlackExport/App.config
@@ -16,9 +16,12 @@
 		</assemblyBinding>
 	</runtime>
 	<appSettings>
-		<add key="token" value="SlackAPIのトークンをセットする" />
+		<add key="token" value="Slackのトークンをセットします" />
 		<add key="mySqlConnection" value="server=127.0.0.1;port=3306;uid=user;pwd=password;database=DiarySample" />
 		<add key="importFilePath" value="インポートファイルを格納しているフォルダのパスをセットする" />
 		<add key="daysAgo" value="90" />
+		<add key="awsCliProfile" value="AWSCLIのプロファイル名をセットします" />
+		<add key="awsBucketName" value="1-system-group-slack-history" />
+		<add key="awsObjectPath" value="archive" />
 	</appSettings>
 </configuration>

--- a/SlackExport/Common/AmazonS3Access.cs
+++ b/SlackExport/Common/AmazonS3Access.cs
@@ -1,0 +1,43 @@
+﻿using System.Configuration;
+using Amazon.Runtime.CredentialManagement;
+using Amazon.S3;
+using Amazon.S3.Transfer;
+
+namespace SlackExport.Common
+{
+    public class AmazonS3Access
+    {
+        private AmazonS3Client client;
+        public AmazonS3Access()
+        {
+
+            // ～ユーザ/.aws/credentials
+            // にアクセスキーとシークレットキーを持ったプロファイルが存在していることが前提になります
+            string profileName = ConfigurationManager.AppSettings["awsCliProfile"];
+            var credentilasFile = new SharedCredentialsFile();
+
+            CredentialProfile profile = null;
+            if (credentilasFile.TryGetProfile(profileName, out profile) == false)
+            {
+                System.Diagnostics.Debug.WriteLine("プロファイル名は存在しません。");
+                return;
+            }
+
+            Amazon.Runtime.AWSCredentials awsCredentials = null;
+            if (AWSCredentialsFactory.TryGetAWSCredentials(profile, credentilasFile, out awsCredentials) == false)
+            {
+                System.Diagnostics.Debug.WriteLine("認証情報の生成に失敗しました。");
+                return;
+            }
+
+            client = new AmazonS3Client(awsCredentials, profile.Region);
+
+        }
+
+        public void UploadFile(string filePath, string bucketName, string objectKey)
+        {
+            TransferUtility fileTransferUtility = new TransferUtility(client);
+            fileTransferUtility.Upload(filePath, bucketName, objectKey);
+        }
+    }
+}

--- a/SlackExport/SlackExport.csproj
+++ b/SlackExport/SlackExport.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="3.7.205.3" />
     <PackageReference Include="MySqlConnector" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.1.5" />


### PR DESCRIPTION
コマンドライン引数に"2"を指定した場合に、Slackから投稿記事をエクスポートしますが、
エクスポートした結果をzipにしてS3にエクスポートするようにしました。
エクスポート対象（バケット名、オブジェクトキーのパス）はApp.configに指定できます。

また、S3エクスポートするために、
C:/～ユーザ/.aws/credentialsに、
にアクセスキーとシークレットキーを持ったプロファイルが存在していることが前提になります