### PR TITLE
S3からzipファイル群を取得してDBにインポートする

### DIFF
--- a/SlackExport/App.config
+++ b/SlackExport/App.config
@@ -16,8 +16,6 @@
 		</assemblyBinding>
 	</runtime>
 	<appSettings>
-		<add key="mySqlConnection" value="server=127.0.0.1;port=3306;uid=user;pwd=password;database=DiarySample" />
-		<add key="importFilePath" value="インポートファイルを格納しているフォルダのパスをセットする" />
 		<add key="daysAgo" value="90" />
 		<add key="awsBucketName" value="1-system-group-slack-history" />
 		<add key="awsObjectPath" value="archive" />

--- a/SlackExport/Common/AmazonS3Access.cs
+++ b/SlackExport/Common/AmazonS3Access.cs
@@ -28,5 +28,12 @@ namespace SlackExport.Common
             TransferUtility fileTransferUtility = new TransferUtility(client);
             fileTransferUtility.Upload(filePath, bucketName, objectKey);
         }
+
+        public void DownLoadFile(string localPath, string bucketName, string objectKey)
+        {
+            TransferUtility fileTransferUtility = new TransferUtility(client);
+
+            fileTransferUtility.DownloadDirectory(bucketName, objectKey, localPath);
+        }
     }
 }

--- a/SlackExport/Common/DbAccess.cs
+++ b/SlackExport/Common/DbAccess.cs
@@ -14,9 +14,9 @@ namespace SlackExport.Common
         public bool Insert(DataDto dataDto)
         {
             // 実行するSQL
-            var sql = "INSERT INTO diary (id, title, content, post_date, update_date)  SELECT COALESCE(MAX(id), 0) + 1, @title, @content, @post_date, @update_date FROM diary";
+            var sql = " INSERT INTO diary (title, content, post_date, update_date) VALUES (@title, @content, @post_date, @update_date)";
 
-            using (var connection = new MySqlConnection(Environment.GetEnvironmentVariable("mySqlConnection")))
+            using (var connection = new MySqlConnection(Environment.GetEnvironmentVariable("MY_SQL_CONNECTION")))
             {
                 using (var command = new MySqlCommand(sql, connection))
                 {
@@ -53,7 +53,7 @@ namespace SlackExport.Common
         {
             // 実行するSQL
             string sql = "SELECT COUNT(*) AS count FROM diary WHERE title = @title";
-            using (var connection = new MySqlConnection(Environment.GetEnvironmentVariable("mySqlConnection")))
+            using (var connection = new MySqlConnection(Environment.GetEnvironmentVariable("MY_SQL_CONNECTION")))
             {
                 using (var command = new MySqlCommand(sql, connection))
                 {

--- a/SlackExport/Common/DbAccess.cs
+++ b/SlackExport/Common/DbAccess.cs
@@ -14,9 +14,9 @@ namespace SlackExport.Common
         public bool Insert(DataDto dataDto)
         {
             // 実行するSQL
-            var sql = "INSERT INTO diary (id, title, content, post_date, update_date)  SELECT MAX(id) + 1, @title, @content, @post_date, @update_date FROM diary";
+            var sql = "INSERT INTO diary (id, title, content, post_date, update_date)  SELECT COALESCE(MAX(id), 0) + 1, @title, @content, @post_date, @update_date FROM diary";
 
-            using (var connection = new MySqlConnection(ConfigurationManager.AppSettings["mySqlConnection"]))
+            using (var connection = new MySqlConnection(Environment.GetEnvironmentVariable("mySqlConnection")))
             {
                 using (var command = new MySqlCommand(sql, connection))
                 {
@@ -53,7 +53,7 @@ namespace SlackExport.Common
         {
             // 実行するSQL
             string sql = "SELECT COUNT(*) AS count FROM diary WHERE title = @title";
-            using (var connection = new MySqlConnection(ConfigurationManager.AppSettings["mySqlConnection"]))
+            using (var connection = new MySqlConnection(Environment.GetEnvironmentVariable("mySqlConnection")))
             {
                 using (var command = new MySqlCommand(sql, connection))
                 {

--- a/SlackExport/Service/FileExportService.cs
+++ b/SlackExport/Service/FileExportService.cs
@@ -9,7 +9,7 @@ namespace SlackExport.Service
     public class FileExportService
     {
         // TODO:App.configに移す想定
-        private static readonly string ROOT_PATH = "./work";
+        private static readonly string ROOT_PATH = "./exportwork";
 
         private static readonly string EXPORT_NAME = "第一システム部（仮） Slack export";
 

--- a/SlackExport/Service/FileImportService.cs
+++ b/SlackExport/Service/FileImportService.cs
@@ -31,7 +31,6 @@ namespace SlackExport.Service
 
         public void Execute()
         {
-
             // S3からダウンロードしてきたファイルを格納するパスを作成
             Directory.CreateDirectory(S3_DOWNLOAD_TEMPORARY_PATH);
             // S3からダウンロード
@@ -43,7 +42,7 @@ namespace SlackExport.Service
            
             // ダウンロードしてきたファイルを全て解凍する
             DecompressionDirectory(S3_DOWNLOAD_TEMPORARY_PATH, S3_DOWNLOAD_TEMPORARY_PATH_DECOMPRESS);
-
+            
             var fileDtoList = new List<FileDto>();
             // ファイル格納パスを読み込んで、ファイルのリストを作成する
             Read("", S3_DOWNLOAD_TEMPORARY_PATH_DECOMPRESS, fileDtoList);
@@ -243,7 +242,7 @@ namespace SlackExport.Service
             // あらかじめ問い合わせておくようなことはしない
             if (userInfoDec == null)
             {
-                string token = ConfigurationManager.AppSettings["token"];
+                string token = Environment.GetEnvironmentVariable("SLACK_TOKEN");
                 var slackApiAccess = new SlackApiAccess();
                 userInfoDec = slackApiAccess.GetUserInfo(token);
             }


### PR DESCRIPTION
S3にzip形式で格納されているSlackのアーカイブファイル群を取得してきてDBにインポートするようにしました。

・zip形式で取得してくるので、取得したら、いったん全てのzipを解凍してからインポートを行います。

・環境変数に、`mySqlConnection：server=xxx.xxx.xxx.xxxx;port=xxxx;uid=xxxx;pwd=xxxx;database=xxxx`の形式で登録されていることが前提になります。このDBにインポートしにいきます。

・現状はインポートする際に、日時順にはなっていないです。
　アーカイブファイル群のファイル名が`{Slack名} Slack export Jan 20 2024 - Mar 23 2024`みたいな形式で、
　アーカイブを取った際の開始・終了の日時になっていて、中のテキストも重複していたりするので、　
　中のテキストを読み込む時のソートが面倒のため、やれていないです。
　やるとしたら、いったんテンポラリテーブル（を作って）にインポートして、その後に日時順にソートしつつdiaryテーブルに格納した方が良さそうです。

・1投稿につき1insert発行なので、初回だとアーカイブファイル群を全部読み込むことから、結構なinsert文を発行しますが、
　2回目以降は差分のみなのと、そこまで頻繁に投稿していないので、そこは大丈夫かなと思っています。
　（ただ、常にアーカイブファイル群を全件取得するので、そこは無駄が多い気はしています）

・レコード0件の場合にdiary.idが1開始になっていなかったので、1開始にしました。

・ローカルでherokuの参照先DBに入れてみて、入ることを確認しています。（下記の※）
　ただ、改行が考慮されていませんでしたね…。ここは改善した方がいいかな…。
　また、動作確認時に入れたデータはいったんdeleteして、herokuにデプロイ後に手動で一回動かして全件インポートして、
　その後は月イチくらいの実行にして差分をインポートみたいな運用になるかと思います。（問題あればご指摘いただければと…）
　

