### PR TITLE
SQLを一括で行う

### DIFF
--- a/SlackExport/Common/DbAccess.cs
+++ b/SlackExport/Common/DbAccess.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Configuration;
+﻿using System.Data;
 using MySqlConnector;
 using NLog;
 using SlackExport.Dto;
@@ -8,10 +7,13 @@ namespace SlackExport.Common
 {
     public class DbAccess
     {
+        // 一度に登録する件数の上限
+        private static readonly int BATCH_INSERT_MAX_NUM = 1000;
+
         // ログを出力するロガー定義
         public static Logger logger = LogManager.GetCurrentClassLogger();
 
-        public bool Insert(DataDto dataDto)
+        public bool InsertDiary(DataDto dataDto)
         {
             // 実行するSQL
             var sql = " INSERT INTO diary (title, content, post_date, update_date) VALUES (@title, @content, @post_date, @update_date)";
@@ -28,7 +30,7 @@ namespace SlackExport.Common
                         command.CommandText = sql;
                         // バインド変数をセット
                         // タイトルは「チャンネル名 + 日時 + ユーザ名」の形式にする
-                        command.Parameters.AddWithValue("@title", dataDto.thread + "_" + dataDto.ts + "_" + dataDto.user);
+                        command.Parameters.AddWithValue("@title", dataDto.title);
                         command.Parameters.AddWithValue("@content", dataDto.message);
                         command.Parameters.AddWithValue("@post_date", dataDto.ts);
                         command.Parameters.AddWithValue("@update_date", dataDto.ts);
@@ -49,7 +51,7 @@ namespace SlackExport.Common
             return true;
         }
 
-        public bool CheckRegistered(DataDto dataDto)
+        public bool CheckRegisteredDiary(DataDto dataDto)
         {
             // 実行するSQL
             string sql = "SELECT COUNT(*) AS count FROM diary WHERE title = @title";
@@ -96,6 +98,127 @@ namespace SlackExport.Common
 
                     return false;
                 }
+            }
+        }
+
+        public List<string> SelectRegisteredDiaryTitleList()
+        {
+            // 実行するSQL
+            string sql = "SELECT title AS title FROM diary";
+            using (var connection = new MySqlConnection(Environment.GetEnvironmentVariable("MY_SQL_CONNECTION")))
+            {
+                using (var command = new MySqlCommand(sql, connection))
+                {
+                    try
+                    {
+                        // 接続の確立
+                        connection.Open();
+                        command.Connection = connection;
+                        command.CommandText = sql;
+
+
+                        var dataTable = new DataTable();
+                        dataTable.Load(command.ExecuteReader());
+
+                        var list = dataTable.AsEnumerable().Select(x => x["title"].ToString()).ToList();
+
+                        return list;
+
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Error("登録済みタイトル一括取得のselect文発行で例外エラー。 エラー内容：" + ex.Message + " スタックトレース：" + ex.StackTrace);
+                    }
+
+                }
+            }
+            return [];
+        }
+
+
+        public void InsertsDiary(List<DataDto> dataDtoList)
+        {
+            int insertNum = dataDtoList.Count;
+
+            if (insertNum == 0)
+            {
+                return;
+            }
+
+            using (var connection = new MySqlConnection(Environment.GetEnvironmentVariable("MY_SQL_CONNECTION")))
+            {
+                // 接続の確立
+                connection.Open();
+
+                // 一括登録件数単位のカウンタ
+                int batchInsertNum = (insertNum / BATCH_INSERT_MAX_NUM) + 1;
+
+                for (int i = 0; i < batchInsertNum; i++)
+                {
+                    // 上限件数毎に抜き出して登録していく
+                    // 仮に上限件数が1000だとしたら、
+                    // start:0 end:1000、start:1000 end:1000、start:2000 end:1000
+                    // というように1000件ずつ抜き出していく
+                    int startNum = BATCH_INSERT_MAX_NUM * i;
+                    int endNum = BATCH_INSERT_MAX_NUM;
+                    // endが上限未満の場合は、あるところまでに補正する
+                    // 仮に上限件数が1000件の場合に、リストが600件まで場合は、satrt:0~end:600にする)
+                    int listCount = dataDtoList.Count;
+                    int listEndCount = listCount - (BATCH_INSERT_MAX_NUM * i);
+                    if (endNum > listEndCount)
+                    {
+                        endNum = listEndCount;
+                    }
+
+                    var insertDataDtoList = dataDtoList.GetRange(startNum, endNum);
+
+                    var insertSql = " INSERT INTO diary (title, content, post_date) VALUES ";
+                    int sqlRowNum = 1;
+                    foreach (var insertDataDto in insertDataDtoList)
+                    {
+                        string valuesSql;
+                        if (sqlRowNum == 1)
+                        {
+                            valuesSql = " (@title" + sqlRowNum + ", @content" + sqlRowNum + ", @post_date" + sqlRowNum + ") ";
+                        }
+                        else
+                        {
+                            valuesSql = ", (@title" + sqlRowNum + ", @content" + sqlRowNum + ", @post_date" + sqlRowNum + ") ";
+                        }
+
+                        insertSql += valuesSql;
+                        sqlRowNum++;
+                    }
+
+                    using (var command = new MySqlCommand(insertSql, connection))
+                    {
+                        try
+                        {
+                            command.Connection = connection;
+                            command.CommandText = insertSql;
+
+                            int valRowNum = 1;
+                            foreach (var insertDataDto in insertDataDtoList)
+                            {
+                                // バインド変数をセット
+                                command.Parameters.AddWithValue("@title" + valRowNum, insertDataDto.title);
+                                command.Parameters.AddWithValue("@content" + valRowNum, insertDataDto.message);
+                                command.Parameters.AddWithValue("@post_date" + valRowNum, insertDataDto.ts);
+                                valRowNum++;
+                            }
+                            var result = command.ExecuteNonQuery();
+                            if (result == 0)
+                            {
+                                logger.Error("insert文でエラー");
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.Error("insert文発行で例外エラー。 エラー内容：" + ex.Message + " スタックトレース：" + ex.StackTrace);
+                        }
+                    }
+                }
+                connection.Close();
             }
         }
     }

--- a/SlackExport/Common/DbAccess.cs
+++ b/SlackExport/Common/DbAccess.cs
@@ -7,99 +7,8 @@ namespace SlackExport.Common
 {
     public class DbAccess
     {
-        // 一度に登録する件数の上限
-        private static readonly int BATCH_INSERT_MAX_NUM = 1000;
-
         // ログを出力するロガー定義
         public static Logger logger = LogManager.GetCurrentClassLogger();
-
-        public bool InsertDiary(DataDto dataDto)
-        {
-            // 実行するSQL
-            var sql = " INSERT INTO diary (title, content, post_date, update_date) VALUES (@title, @content, @post_date, @update_date)";
-
-            using (var connection = new MySqlConnection(Environment.GetEnvironmentVariable("MY_SQL_CONNECTION")))
-            {
-                using (var command = new MySqlCommand(sql, connection))
-                {
-                    try
-                    {
-                        // 接続の確立
-                        connection.Open();
-                        command.Connection = connection;
-                        command.CommandText = sql;
-                        // バインド変数をセット
-                        // タイトルは「チャンネル名 + 日時 + ユーザ名」の形式にする
-                        command.Parameters.AddWithValue("@title", dataDto.title);
-                        command.Parameters.AddWithValue("@content", dataDto.message);
-                        command.Parameters.AddWithValue("@post_date", dataDto.ts);
-                        command.Parameters.AddWithValue("@update_date", dataDto.ts);
-
-                        var result = command.ExecuteNonQuery();
-                        if (result != 1)
-                        {
-                            logger.Error("insert文でエラー。タイトル：" + dataDto.thread + "_" + dataDto.ts + "_" + dataDto.user);
-                        }
-                        connection.Close();
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.Error("insert文発行で例外エラー。タイトル：" + dataDto.thread + "_" + dataDto.ts + "_" + dataDto.user + " エラー内容：" + ex.Message + " スタックトレース：" + ex.StackTrace);
-                    }
-                }
-            }
-            return true;
-        }
-
-        public bool CheckRegisteredDiary(DataDto dataDto)
-        {
-            // 実行するSQL
-            string sql = "SELECT COUNT(*) AS count FROM diary WHERE title = @title";
-            using (var connection = new MySqlConnection(Environment.GetEnvironmentVariable("MY_SQL_CONNECTION")))
-            {
-                using (var command = new MySqlCommand(sql, connection))
-                {
-                    try
-                    {
-                        // 接続の確立
-                        connection.Open();
-                        command.Connection = connection;
-                        command.CommandText = sql;
-
-                        // タイトル
-                        string title = dataDto.thread + "_" + dataDto.ts + "_" + dataDto.user;
-
-                        // バインド変数をセット
-                        command.Parameters.AddWithValue("@title", title);
-
-                        using (var reader = command.ExecuteReader())
-                        {
-                            if (reader.Read())
-                            {
-
-                                if (int.Parse(reader["count"].ToString()) > 0)
-                                {
-                                    logger.Info("登録済み：" + title);
-                                    return true;
-                                }
-                            }
-                            else
-                            {
-                                logger.Error("select文でエラー。：" + dataDto.thread + "_" + dataDto.ts + "_" + dataDto.user);
-                                return true;
-                            }
-                        }
-
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.Error("select文発行で例外エラー。タイトル：" + dataDto.thread + "_" + dataDto.ts + "_" + dataDto.user + " エラー内容：" + ex.Message + " スタックトレース：" + ex.StackTrace);
-                    }
-
-                    return false;
-                }
-            }
-        }
 
         public List<string> SelectRegisteredDiaryTitleList()
         {
@@ -136,7 +45,7 @@ namespace SlackExport.Common
         }
 
 
-        public void InsertsDiary(List<DataDto> dataDtoList)
+        public void InsertDiaryList(List<DataDto> dataDtoList)
         {
             int insertNum = dataDtoList.Count;
 
@@ -150,74 +59,37 @@ namespace SlackExport.Common
                 // 接続の確立
                 connection.Open();
 
-                // 一括登録件数単位のカウンタ
-                int batchInsertNum = (insertNum / BATCH_INSERT_MAX_NUM) + 1;
+                var insertSql = " INSERT INTO diary (title, content, post_date) VALUES " +
+                    string.Join(",", dataDtoList.Select((_, index) => $"(@title{index + 1}, @content{index + 1}, @post_date{index + 1})"));
 
-                for (int i = 0; i < batchInsertNum; i++)
+                using (var command = new MySqlCommand(insertSql, connection))
                 {
-                    // 上限件数毎に抜き出して登録していく
-                    // 仮に上限件数が1000だとしたら、
-                    // start:0 end:1000、start:1000 end:1000、start:2000 end:1000
-                    // というように1000件ずつ抜き出していく
-                    int startNum = BATCH_INSERT_MAX_NUM * i;
-                    int endNum = BATCH_INSERT_MAX_NUM;
-                    // endが上限未満の場合は、あるところまでに補正する
-                    // 仮に上限件数が1000件の場合に、リストが600件まで場合は、satrt:0~end:600にする)
-                    int listCount = dataDtoList.Count;
-                    int listEndCount = listCount - (BATCH_INSERT_MAX_NUM * i);
-                    if (endNum > listEndCount)
+                    try
                     {
-                        endNum = listEndCount;
+                        command.Connection = connection;
+                        command.CommandText = insertSql;
+
+                        int valRowNum = 1;
+                        foreach (var insertDataDto in dataDtoList)
+                        {
+                            // バインド変数をセット
+                            command.Parameters.AddWithValue("@title" + valRowNum, insertDataDto.title);
+                            command.Parameters.AddWithValue("@content" + valRowNum, insertDataDto.message);
+                            command.Parameters.AddWithValue("@post_date" + valRowNum, insertDataDto.ts);
+                            valRowNum++;
+                        }
+                        var result = command.ExecuteNonQuery();
+                        if (result == 0)
+                        {
+                            logger.Error("insert文でエラー");
+                        }
                     }
-
-                    var insertDataDtoList = dataDtoList.GetRange(startNum, endNum);
-
-                    var insertSql = " INSERT INTO diary (title, content, post_date) VALUES ";
-                    int sqlRowNum = 1;
-                    foreach (var insertDataDto in insertDataDtoList)
+                    catch (Exception ex)
                     {
-                        string valuesSql;
-                        if (sqlRowNum == 1)
-                        {
-                            valuesSql = " (@title" + sqlRowNum + ", @content" + sqlRowNum + ", @post_date" + sqlRowNum + ") ";
-                        }
-                        else
-                        {
-                            valuesSql = ", (@title" + sqlRowNum + ", @content" + sqlRowNum + ", @post_date" + sqlRowNum + ") ";
-                        }
-
-                        insertSql += valuesSql;
-                        sqlRowNum++;
-                    }
-
-                    using (var command = new MySqlCommand(insertSql, connection))
-                    {
-                        try
-                        {
-                            command.Connection = connection;
-                            command.CommandText = insertSql;
-
-                            int valRowNum = 1;
-                            foreach (var insertDataDto in insertDataDtoList)
-                            {
-                                // バインド変数をセット
-                                command.Parameters.AddWithValue("@title" + valRowNum, insertDataDto.title);
-                                command.Parameters.AddWithValue("@content" + valRowNum, insertDataDto.message);
-                                command.Parameters.AddWithValue("@post_date" + valRowNum, insertDataDto.ts);
-                                valRowNum++;
-                            }
-                            var result = command.ExecuteNonQuery();
-                            if (result == 0)
-                            {
-                                logger.Error("insert文でエラー");
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.Error("insert文発行で例外エラー。 エラー内容：" + ex.Message + " スタックトレース：" + ex.StackTrace);
-                        }
+                        logger.Error("insert文発行で例外エラー。 エラー内容：" + ex.Message + " スタックトレース：" + ex.StackTrace);
                     }
                 }
+
                 connection.Close();
             }
         }

--- a/SlackExport/Dto/DataDto.cs
+++ b/SlackExport/Dto/DataDto.cs
@@ -5,6 +5,7 @@
         public string thread { get; set; }
         public string ts { get; set; }
         public string user { get; set; }
+        public string title { get; set; }
         public string message { get; set; }
     }
 }

--- a/SlackExport/Service/FileImportService.cs
+++ b/SlackExport/Service/FileImportService.cs
@@ -62,10 +62,10 @@ namespace SlackExport.Service
                 {
                     // 別のアーカイブファイルで同じ投稿データがある可能性があるので、
                     // 同じ投稿データがあったら除外するため、判定要素としてdataDtoListも渡す
-                    var devrlipRegistDataDtoList = DevelopRegst(fileDto, titleList, dataDtoList);
-                    if (devrlipRegistDataDtoList.Count > 0)
+                    var developRegistDataDtoList = getRegistDataList(fileDto, titleList, dataDtoList);
+                    if (developRegistDataDtoList.Count > 0)
                     {
-                        dataDtoList.AddRange(devrlipRegistDataDtoList);
+                        dataDtoList.AddRange(developRegistDataDtoList);
                     }
                 }
                 // github通知チャンネル
@@ -82,7 +82,7 @@ namespace SlackExport.Service
             }
 
             // diaryテーブルにインポートする
-            dbAccess.InsertsDiary(dataDtoList);
+            dbAccess.InsertDiaryList(dataDtoList);
 
             // S3からダウンロードしてきたファイルを格納するパス（解凍した分も含めて）を削除
             Directory.Delete(S3_DOWNLOAD_TEMPORARY_PATH, true);
@@ -130,7 +130,7 @@ namespace SlackExport.Service
         }
 
         // 開発チャンネル分のインポート
-        private List<DataDto> DevelopRegst(FileDto fileDto, List<string> titleList, List<DataDto> dataDtoList)
+        private List<DataDto> getRegistDataList(FileDto fileDto, List<string> titleList, List<DataDto> dataDtoList)
         {
             var registDataDtoList = new List<DataDto>();
             try

--- a/SlackExport/Service/FileImportService.cs
+++ b/SlackExport/Service/FileImportService.cs
@@ -62,7 +62,7 @@ namespace SlackExport.Service
                 {
                     // 別のアーカイブファイルで同じ投稿データがある可能性があるので、
                     // 同じ投稿データがあったら除外するため、判定要素としてdataDtoListも渡す
-                    var developRegistDataDtoList = getRegistDataList(fileDto, titleList, dataDtoList);
+                    var developRegistDataDtoList = GetRegistDataList(fileDto, titleList, dataDtoList);
                     if (developRegistDataDtoList.Count > 0)
                     {
                         dataDtoList.AddRange(developRegistDataDtoList);
@@ -130,7 +130,7 @@ namespace SlackExport.Service
         }
 
         // 開発チャンネル分のインポート
-        private List<DataDto> getRegistDataList(FileDto fileDto, List<string> titleList, List<DataDto> dataDtoList)
+        private List<DataDto> GetRegistDataList(FileDto fileDto, List<string> titleList, List<DataDto> dataDtoList)
         {
             var registDataDtoList = new List<DataDto>();
             try
@@ -208,7 +208,7 @@ namespace SlackExport.Service
                             {
                                 // 保持しておいたuserにも見つからない場合、
                                 // SlackAPIからユーザ名を取得する
-                                string slackApiName = getUserFromSlack(user);
+                                string slackApiName = GetUserFromSlack(user);
                                 if (slackApiName != string.Empty)
                                 {
                                     name = slackApiName;
@@ -256,7 +256,7 @@ namespace SlackExport.Service
 
         }
 
-        private string getUserFromSlack(string userId)
+        private string GetUserFromSlack(string userId)
         {
             string userName = string.Empty;
 


### PR DESCRIPTION
diaryテーブルに登録済みのタイトルをごっそり抜き出してメモリに持たせておいて、
それに重複確認をするようにしたのと、
insertを、1投稿1insertだったところを、1000件までは1insertにするように修正しています。
（あと、日付のカラムもオールゼロにならないようになっている…と思います。
　ローカルからだと大丈夫だったので、あとはherokuでの動作確認になります）

上記のことから、DbAccess.csのInsertsDiary()を大きく変えています。

MySqlConnection + MySqlCommandでは、バッチインサートやバルクインサートのAPIが見当たらなかったので、
仕方なく自分で、`insert into (xxx) values (xxx), (xxx), (xxx), (xxx)`を組み立てて投げる方式にしています。
性能的に大丈夫なやり方なのかが結構気になりますけど、とりあえず一度に1000件までにしているので、
月次バッチ想定であることもあり、大丈夫だと思っています。

また、上記のvalues以降を件数分組み立てている箇所（177行目近辺）と、
それにバインド変数をセットする箇所（201行目近辺）で、
同じリストを二度ループさせていますが、上手く統合できなかったので仕方ないというところです。
これも月次バッチ想定なので、許容範囲内かなと思っています。

エラー処理についても、ある程度ログだけ出して続行させています。
DB接続エラーなんかが出た場合は終了させた方がいいのですが、
そういう環境下で動作させることはあまりないと思うので、とりあえず続行にしています。
（あとで見直してもいいかなと思っています）

修正前の一件登録の関数も、一応残してあります。